### PR TITLE
Add 'sats_to_msats' function to assign correct 'amount_msat' values

### DIFF
--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -203,6 +203,10 @@ impl DescriptorWallet {
         })
     }
 
+    fn sats_to_msats(amount: u64) -> u64 {
+        amount * 1000
+    }
+
     // pub fn update_last_synced(&mut self, last_synced: BlockTime) {
     //     self.last_synced = Some(last_synced);
     // }
@@ -347,7 +351,7 @@ impl DescriptorWallet {
                                     "account": acct,
                                     "outpoint": outpoint,
                                     "spending_txid": tx.txid.to_string(),
-                                    "amount_msat": amount,
+                                    "amount_msat": Self::sats_to_msats(amount),
                                     "coin_type": "bcrt",
                                     "timestamp": format!("{}", time),
                                     "blockheight": format!("{}", height),
@@ -399,7 +403,7 @@ impl DescriptorWallet {
                                     "transfer_from": transfer_from,
                                     "outpoint": outpoint,
                                     "spending_txid": tx.txid.to_string(),
-                                    "amount_msat": amount,
+                                    "amount_msat": Self::sats_to_msats(amount),
                                     "coin_type": "bcrt",
                                     "timestamp": format!("{}", time),
                                     "blockheight": format!("{}", height),
@@ -471,7 +475,7 @@ impl DescriptorWallet {
                                         "transfer_from": transfer_from,
                                         "outpoint": outpoint,
                                         "spending_txid": tx.txid.to_string(),
-                                        "amount_msat": amount,
+                                        "amount_msat": Self::sats_to_msats(amount),
                                         "coin_type": "bcrt",
                                         "timestamp": format!("{}", time),
                                         "blockheight": format!("{}", height),
@@ -530,7 +534,7 @@ impl DescriptorWallet {
                                         "account": acct,
                                         "outpoint": outpoint,
                                         "spending_txid": tx.txid.to_string(),
-                                        "amount_msat": amount,
+                                        "amount_msat": Self::sats_to_msats(amount),
                                         "coin_type": "bcrt",
                                         "timestamp": format!("{}", time),
                                         "blockheight": format!("{}", height),
@@ -589,7 +593,7 @@ impl DescriptorWallet {
                                     "transfer_from": transfer_from,
                                     "outpoint": outpoint,
                                     "spending_txid": tx.txid.to_string(),
-                                    "amount_msat": amount,
+                                    "amount_msat": Self::sats_to_msats(amount),
                                     "coin_type": "bcrt",
                                     "timestamp": format!("{}", time),
                                     "blockheight": format!("{}", height),


### PR DESCRIPTION
Tested  by calling `l1-cli smaug add`.
`balance_msat` now shows the correct value in msats:
```
{
    "account": "smaug:5ysl7j8h9s47r8h0",
     "balances": [
        {
           "balance_msat": 85942131000,
           "coin_type": "bcrt"
        }
     ]
}
```
where previously it displayed the amount in sats.